### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/openjub/openjub-api.png?label=ready&title=Ready)](https://waffle.io/openjub/openjub-api)
 ![](public/images/logo_small.png)
 
 # OpenJUB API


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/openjub/openjub-api

This was requested by a real person (user dkundel) on waffle.io, we're not trying to spam you.
